### PR TITLE
fix: Don't run eval() unless the script is called directly

### DIFF
--- a/task.py
+++ b/task.py
@@ -20,4 +20,5 @@ def doomla():
     )
 
 
-eval(doomla)
+if __name__ == "__main__":
+    eval(doomla)


### PR DESCRIPTION
### Description
This change allows users to use `inspect eval task.py` with different param overrides on the CLI.

### Testing
```
inspect eval task.py --model openai/gpt-4o-mini
```
worked as expected.